### PR TITLE
Naming Conventions

### DIFF
--- a/src/main/proto/client.v3.proto
+++ b/src/main/proto/client.v3.proto
@@ -33,8 +33,8 @@ message Request {
 
 message Record {
     bytes id = 1;
-    uint64 endMillisSinceEpoch = 2;
-    uint64 startMillisSinceEpoch = 3;
+    uint64 end_millis_since_epoch = 2;
+    uint64 start_millis_since_epoch = 3;
     repeated DimensionEntry dimensions = 4;
     repeated MetricDataEntry data = 5;
 }
@@ -49,13 +49,13 @@ message MetricDataEntry {
     oneof data {
         // All data implementations should provide a
         // samples and statistics field.
-        NumericalData numericalData = 2;
+        NumericalData numerical_data = 2;
     }
 }
 
 message Identifier {
     oneof value {
-        string stringValue = 1;
+        string string_value = 1;
     }
 }
 


### PR DESCRIPTION
Conform to Protocol Buffer naming conventions. This should be binary compatible, and ideally generate compatible code in most languages.

Ref:
https://developers.google.com/protocol-buffers/docs/style