### PR TITLE
Upgrade the bucket count from an int32 to a uint64

### DIFF
--- a/src/main/proto/client.v3.proto
+++ b/src/main/proto/client.v3.proto
@@ -78,5 +78,5 @@ message AugmentedHistogram {
 
 message SparseHistogramEntry {
     int64 bucket = 1;
-    int32 count = 2;
+    uint64 count = 2;
 }


### PR DESCRIPTION
Changing the type is backwards compatible within the int type. 

Ref:
https://developers.google.com/protocol-buffers/docs/proto3#updating